### PR TITLE
doc: fix typo in section `transient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ const createLogger = (tag) => (message) => console.log(`[${tag}] ${message}`);
 
 const parent = createContainer();
 parent.bindValue(TAG, 'parent');
-parent.bindFactory(LOGGER, injectable(createLogger, TAG), {scope: 'singleton'});
+parent.bindFactory(LOGGER, injectable(createLogger, TAG), {scope: 'transient'});
 
 const container1 = createContainer(parent);
 container1.bindValue(TAG, 'container1');


### PR DESCRIPTION
Hi. Noticed a small typo in the documentation and decided to help out an interesting project a bit :-)